### PR TITLE
Add build CONFIG Docker build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM swiftlang/swift:nightly-5.7-focal
+ARG CONFIG=debug
 WORKDIR /build
 COPY . .
-RUN swift build --configuration debug
-ENTRYPOINT [ ".build/debug/HelloFlyDistributedActors" ]
+RUN swift build --configuration $CONFIG
+CMD .build/$CONFIG/HelloFlyDistributedActors

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ ARG CONFIG=debug
 WORKDIR /build
 COPY . .
 RUN swift build --configuration $CONFIG
+ENV $CONFIG ${CONFIG}
 CMD .build/$CONFIG/HelloFlyDistributedActors

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /build
 COPY . .
 RUN swift build --configuration $CONFIG
 ENV $CONFIG ${CONFIG}
-CMD .build/$CONFIG/HelloFlyDistributedActors
+CMD .build/${CONFIG}/HelloFlyDistributedActors

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM swiftlang/swift:nightly-5.7-focal
 ARG CONFIG=debug
+RUN [ "$CONFIG" = "debug" ] || [ "$CONFIG" = "release" ] || (echo "CONFIG must be debug or release"; exit 1)
 WORKDIR /build
 COPY . .
 RUN swift build --configuration $CONFIG

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /build
 COPY . .
 RUN swift build --configuration $CONFIG
 ENV $CONFIG=${CONFIG}
-CMD .build/${CONFIG}/HelloFlyDistributedActors
+CMD .build/$CONFIG/HelloFlyDistributedActors

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ ARG CONFIG=debug
 WORKDIR /build
 COPY . .
 RUN swift build --configuration $CONFIG
-ENV $CONFIG=${CONFIG}
+ENV CONFIG=${CONFIG}
 CMD .build/$CONFIG/HelloFlyDistributedActors

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ ARG CONFIG=debug
 WORKDIR /build
 COPY . .
 RUN swift build --configuration $CONFIG
-ENV $CONFIG ${CONFIG}
+ENV $CONFIG=${CONFIG}
 CMD .build/${CONFIG}/HelloFlyDistributedActors

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Swift Distributed Actors on Fly.io
 
 Test app for Swift Distributed Actors on Fly.io
+
+## Docker CONFIG argument
+A CONFIG argument currently defaulting to `debug` has been defined. It can be used to choose the Swift build configuration to use between `debug` and `release`.


### PR DESCRIPTION
The `CONFIG` Docker arg can be set to either `debug` or `release` (currently is `debug` by default) to select the Swift build configuration